### PR TITLE
Allow GCP service account to be set as a string rather than a local file

### DIFF
--- a/cloudmanager/client.go
+++ b/cloudmanager/client.go
@@ -54,7 +54,7 @@ type Client struct {
 	GCPImageProject         string
 	GCPImageFamily          string
 	GCPDeploymentTemplate   string
-	GCPServiceAccountPath   string
+	GCPServiceAccountKey    string
 	CVSHostName             string
 
 	initOnce      sync.Once
@@ -682,7 +682,7 @@ func (c *Client) CallAPIMethod(method string, baseURL string, params map[string]
 		Method:                method,
 		Params:                params,
 		GCPDeploymentTemplate: c.GCPDeploymentTemplate,
-		GCPServiceAccountPath: c.GCPServiceAccountPath,
+		GCPServiceAccountKey:  c.GCPServiceAccountKey,
 	}, c.Simulator)
 	if err != nil {
 		return statusCode, nil, "", err

--- a/cloudmanager/cloudmanager/restapi/request.go
+++ b/cloudmanager/cloudmanager/restapi/request.go
@@ -3,8 +3,6 @@ package restapi
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -19,21 +17,16 @@ type Request struct {
 	Method                string      `json:"method"`
 	Params                interface{} `json:"params"`
 	GCPDeploymentTemplate string
-	GCPServiceAccountPath string
+	GCPServiceAccountKey  string
 }
 
-func getGCPToken(url string, gcpServiceAccountPath string) (string, error) {
-
-	keyBytes, err := ioutil.ReadFile(gcpServiceAccountPath)
-	if err != nil {
-		return "", fmt.Errorf("Unable to read service account key file  %v", err)
-	}
+func getGCPToken(url string, gcpServiceAccountKey string) (string, error) {
 
 	var c = struct {
 		Email      string `json:"client_email"`
 		PrivateKey string `json:"private_key"`
 	}{}
-	json.Unmarshal(keyBytes, &c)
+	json.Unmarshal([]byte(gcpServiceAccountKey), &c)
 	config := &jwt.Config{
 		Email:      c.Email,
 		PrivateKey: []byte(c.PrivateKey),
@@ -87,7 +80,7 @@ func (r *Request) BuildHTTPReq(host string, token string, audience string, baseU
 			}
 		}
 
-		token, err = getGCPToken(url, r.GCPServiceAccountPath)
+		token, err = getGCPToken(url, r.GCPServiceAccountKey)
 		if err != nil {
 			return nil, err
 		}

--- a/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
+++ b/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
@@ -43,14 +43,14 @@ func resourceOCCMGCP() *schema.Resource {
 			},
 			"service_account_path": {
 				Type:     schema.TypeString,
-				Required: false,
+				Optional: true,
 				ForceNew: true,
 				ConflictsWith: []string{"service_account_key"},
 				Default: "",
 			},
 			"service_account_key": {
 				Type:     schema.TypeString,
-				Required: false,
+				Optional: true,
 				ForceNew: true,
 				ConflictsWith: []string{"service_account_path"},
 				Default: "",
@@ -390,15 +390,15 @@ func resourceOCCMGCPUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func getGCPServiceAccountKey(d *schema.ResourceData) (string, error) {
-	service_account_path := d.Get("service_account_path").(string)
-	service_account_key := d.Get("service_account_key").(string)
-	if service_account_path != "" {
-		service_account_key, err := ioutil.ReadFile(service_account_path)
+	serviceAccountPath := d.Get("service_account_path").(string)
+	serviceAccountKey := d.Get("service_account_key").(string)
+	if serviceAccountPath != "" {
+		serviceAccountKey, err := ioutil.ReadFile(serviceAccountPath)
 		if err != nil {
 			return "", fmt.Errorf("Cannot read service account file: %s", err)
 		}
-		return string(service_account_key), nil
-	} else if service_account_key != "" {
+		return string(serviceAccountKey), nil
+	} else if serviceAccountKey != "" {
 		return d.Get("service_account_key").(string), nil
 
 	}

--- a/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
+++ b/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
@@ -150,15 +150,10 @@ func resourceOCCMGCPCreate(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
 	occmDetails.MachineType = d.Get("machine_type").(string)
 	occmDetails.ServiceAccountEmail = d.Get("service_account_email").(string)
-	service_account_path := d.Get("service_account_path").(string)
-	if service_account_path == "" {
-		service_account_key, err := ioutil.ReadFile(service_account_path)
-		if err != nil {
-			return fmt.Errorf("Cannot read service account file: %s", err)
-		}
-		client.GCPServiceAccountKey = string(service_account_key)
-	} else {
-		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	var err error
+	client.GCPServiceAccountKey, err = getGCPServiceAccountKey(d)
+	if err != nil {
+		return err
 	}
 	occmDetails.FirewallTags = d.Get("firewall_tags").(bool)
 	occmDetails.AssociatePublicIP = d.Get("associate_public_ip").(bool)
@@ -247,15 +242,10 @@ func resourceOCCMGCPRead(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.GCPProject = d.Get("project_id").(string)
 	occmDetails.Region = d.Get("zone").(string)
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
-	service_account_path := d.Get("service_account_path").(string)
-	if service_account_path == "" {
-		service_account_key, err := ioutil.ReadFile(service_account_path)
-		if err != nil {
-			return fmt.Errorf("Cannot read service account file: %s", err)
-		}
-		client.GCPServiceAccountKey = string(service_account_key)
-	} else {
-		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	var err error
+	client.GCPServiceAccountKey, err = getGCPServiceAccountKey(d)
+	if err != nil {
+		return err
 	}
 	occmDetails.Company = d.Get("company").(string)
 	clientID := d.Get("client_id").(string)
@@ -307,15 +297,10 @@ func resourceOCCMGCPDelete(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.InstanceID = id
 	occmDetails.Name = d.Get("name").(string)
 	occmDetails.Project = d.Get("project_id").(string)
-	service_account_path := d.Get("service_account_path").(string)
-	if service_account_path == "" {
-		service_account_key, err := ioutil.ReadFile(service_account_path)
-		if err != nil {
-			return fmt.Errorf("Cannot read service account file: %s", err)
-		}
-		client.GCPServiceAccountKey = string(service_account_key)
-	} else {
-		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	var err error
+	client.GCPServiceAccountKey, err = getGCPServiceAccountKey(d)
+	if err != nil {
+		return err
 	}
 	occmDetails.Region = d.Get("zone").(string)
 	clientID := d.Get("client_id").(string)
@@ -340,15 +325,10 @@ func resourceOCCMGCPExists(d *schema.ResourceData, meta interface{}) (bool, erro
 	occmDetails.GCPProject = d.Get("project_id").(string)
 	occmDetails.Region = d.Get("zone").(string)
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
-	service_account_path := d.Get("service_account_path").(string)
-	if service_account_path == "" {
-		service_account_key, err := ioutil.ReadFile(service_account_path)
-		if err != nil {
-			return false, fmt.Errorf("Cannot read service account file: %s", err)
-		}
-		client.GCPServiceAccountKey = string(service_account_key)
-	} else {
-		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	var err error
+	client.GCPServiceAccountKey, err = getGCPServiceAccountKey(d)
+	if err != nil {
+		return false, err
 	}
 	occmDetails.Company = d.Get("company").(string)
 	clientID := d.Get("client_id").(string)
@@ -380,15 +360,10 @@ func resourceOCCMGCPUpdate(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.GCPProject = d.Get("project_id").(string)
 	occmDetails.Region = d.Get("zone").(string)
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
-	service_account_path := d.Get("service_account_path").(string)
-	if service_account_path == "" {
-		service_account_key, err := ioutil.ReadFile(service_account_path)
-		if err != nil {
-			return fmt.Errorf("Cannot read service account file: %s", err)
-		}
-		client.GCPServiceAccountKey = string(service_account_key)
-	} else {
-		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	var err error
+	client.GCPServiceAccountKey, err = getGCPServiceAccountKey(d)
+	if err != nil {
+		return err
 	}
 	occmDetails.Company = d.Get("company").(string)
 	clientID := d.Get("client_id").(string)
@@ -413,3 +388,20 @@ func resourceOCCMGCPUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	return resourceOCCMGCPRead(d, meta)
 }
+
+func getGCPServiceAccountKey(d *schema.ResourceData) (string, error) {
+	service_account_path := d.Get("service_account_path").(string)
+	service_account_key := d.Get("service_account_key").(string)
+	if service_account_path != "" {
+		service_account_key, err := ioutil.ReadFile(service_account_path)
+		if err != nil {
+			return "", fmt.Errorf("Cannot read service account file: %s", err)
+		}
+		return string(service_account_key), nil
+	} else if service_account_key != "" {
+		return d.Get("service_account_key").(string), nil
+
+	}
+	return "", fmt.Errorf("Neither service_account_path nor service_account_key is set, unable to proceed")
+}
+

--- a/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
+++ b/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
@@ -43,8 +43,17 @@ func resourceOCCMGCP() *schema.Resource {
 			},
 			"service_account_path": {
 				Type:     schema.TypeString,
-				Required: true,
+				Required: false,
 				ForceNew: true,
+				ConflictsWith: []string{"service_account_key"},
+				Default: "",
+			},
+			"service_account_key": {
+				Type:     schema.TypeString,
+				Required: false,
+				ForceNew: true,
+				ConflictsWith: []string{"service_account_path"},
+				Default: "",
 			},
 			"machine_type": {
 				Type:     schema.TypeString,
@@ -140,7 +149,16 @@ func resourceOCCMGCPCreate(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
 	occmDetails.MachineType = d.Get("machine_type").(string)
 	occmDetails.ServiceAccountEmail = d.Get("service_account_email").(string)
-	client.GCPServiceAccountPath = d.Get("service_account_path").(string)
+	service_account_path := d.Get("service_account_path").(string)
+	if service_account_path == "" {
+		service_account_key, err := ioutil.ReadFile(service_account_path)
+		if err != nil {
+			return fmt.Errorf("Cannot read service account file: %s", err)
+		}
+		client.GCPServiceAccountKey = string(service_account_key)
+	} else {
+		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	}
 	occmDetails.FirewallTags = d.Get("firewall_tags").(bool)
 	occmDetails.AssociatePublicIP = d.Get("associate_public_ip").(bool)
 	occmDetails.Company = d.Get("company").(string)
@@ -228,7 +246,16 @@ func resourceOCCMGCPRead(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.GCPProject = d.Get("project_id").(string)
 	occmDetails.Region = d.Get("zone").(string)
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
-	client.GCPServiceAccountPath = d.Get("service_account_path").(string)
+	service_account_path := d.Get("service_account_path").(string)
+	if service_account_path == "" {
+		service_account_key, err := ioutil.ReadFile(service_account_path)
+		if err != nil {
+			return fmt.Errorf("Cannot read service account file: %s", err)
+		}
+		client.GCPServiceAccountKey = string(service_account_key)
+	} else {
+		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	}
 	occmDetails.Company = d.Get("company").(string)
 	clientID := d.Get("client_id").(string)
 
@@ -279,7 +306,16 @@ func resourceOCCMGCPDelete(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.InstanceID = id
 	occmDetails.Name = d.Get("name").(string)
 	occmDetails.Project = d.Get("project_id").(string)
-	client.GCPServiceAccountPath = d.Get("service_account_path").(string)
+	service_account_path := d.Get("service_account_path").(string)
+	if service_account_path == "" {
+		service_account_key, err := ioutil.ReadFile(service_account_path)
+		if err != nil {
+			return fmt.Errorf("Cannot read service account file: %s", err)
+		}
+		client.GCPServiceAccountKey = string(service_account_key)
+	} else {
+		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	}
 	occmDetails.Region = d.Get("zone").(string)
 	clientID := d.Get("client_id").(string)
 	client.AccountID = d.Get("account_id").(string)
@@ -303,7 +339,16 @@ func resourceOCCMGCPExists(d *schema.ResourceData, meta interface{}) (bool, erro
 	occmDetails.GCPProject = d.Get("project_id").(string)
 	occmDetails.Region = d.Get("zone").(string)
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
-	client.GCPServiceAccountPath = d.Get("service_account_path").(string)
+	service_account_path := d.Get("service_account_path").(string)
+	if service_account_path == "" {
+		service_account_key, err := ioutil.ReadFile(service_account_path)
+		if err != nil {
+			return false, fmt.Errorf("Cannot read service account file: %s", err)
+		}
+		client.GCPServiceAccountKey = string(service_account_key)
+	} else {
+		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	}
 	occmDetails.Company = d.Get("company").(string)
 	clientID := d.Get("client_id").(string)
 
@@ -334,7 +379,16 @@ func resourceOCCMGCPUpdate(d *schema.ResourceData, meta interface{}) error {
 	occmDetails.GCPProject = d.Get("project_id").(string)
 	occmDetails.Region = d.Get("zone").(string)
 	occmDetails.SubnetID = d.Get("subnet_id").(string)
-	client.GCPServiceAccountPath = d.Get("service_account_path").(string)
+	service_account_path := d.Get("service_account_path").(string)
+	if service_account_path == "" {
+		service_account_key, err := ioutil.ReadFile(service_account_path)
+		if err != nil {
+			return fmt.Errorf("Cannot read service account file: %s", err)
+		}
+		client.GCPServiceAccountKey = string(service_account_key)
+	} else {
+		client.GCPServiceAccountKey = d.Get("service_account_key").(string)
+	}
 	occmDetails.Company = d.Get("company").(string)
 	clientID := d.Get("client_id").(string)
 

--- a/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
+++ b/cloudmanager/resource_netapp_cloudmanager_connector_gcp.go
@@ -54,6 +54,7 @@ func resourceOCCMGCP() *schema.Resource {
 				ForceNew: true,
 				ConflictsWith: []string{"service_account_path"},
 				Default: "",
+				Sensitive: true,
 			},
 			"machine_type": {
 				Type:     schema.TypeString,

--- a/website/docs/r/connector_gcp.html.markdown
+++ b/website/docs/r/connector_gcp.html.markdown
@@ -42,7 +42,8 @@ The following arguments are supported:
 * `zone` - (Required, non-modifiable) The GCP zone where the Connector will be created.
 * `company` - (Required, non-modifiable) The name of the company of the user.
 * `service_account_email` - (Required, non-modifiable) The email of the service_account for the connector instance. This service account is used to allow the Connector to create Cloud Volume ONTAP.
-* `service_account_path` - (Required, non-modifiable) The local path of the service_account JSON file for GCP authorization purposes. This service account is used to create the Connector in GCP.
+* `service_account_path` - (Optional, non-modifiable) The local path of the service_account JSON file for GCP authorization purposes. This service account is used to create the Connector in GCP.  Either `service_account_path` or `service_account_key` must be set.  Conflicts with `service_account_key`.
+* `service_account_key` - (Optional, non-modifiable) A JSON string for the service account key for GCP authorization purposes.  This service account is used to create the Connector in GCP.  Either `service_account_path` or `service_account_key` must be set.  Conflicts with `service_account_path`.
 * `subnet_id` - (Optional, non-modifiable) The name of the subnet for the virtual machine. The default value is "Default"
 * `network_project_id` - (Optional, non-modifiable) The project id in GCP associated with the Subnet. If not provided, it’s assumed that the Subnet is within the previously specified project id.
 * `machine_type` - (Optional, non-modifiable) The machine_type for the Connector VM. The default value is "n1-standard-4"


### PR DESCRIPTION
This enhances the security of a deployment as it removes the need to store the service account secret key in VCS.  The key will however be stored in the terraform state.  It also allows for a single step deployment where a single terraform module can own the service account, the service account key, all iam, all firewall rules etc;  and all netapp resources.

Closes: https://github.com/NetApp/terraform-provider-netapp-cloudmanager/issues/82

Example:

```
resource "google_service_account" "deploy" {
  account_id  = "netapp-deploy"
  description = "Service account for netapp deployment"
}

resource "google_project_iam_custom_role" "deploy" {
  role_id = "NetAppConnector"
  title   = "NetApp Connector"

  permissions = toset([
    "cloudkms.cryptoKeyVersions.useToEncrypt",
    "cloudkms.cryptoKeys.get",
    "cloudkms.cryptoKeys.list",
    "cloudkms.keyRings.list",
    "compute.addresses.list",
    "compute.backendServices.create",
    "compute.disks.create",
    "compute.disks.createSnapshot",
    "compute.disks.delete",
    "compute.disks.get",
    "compute.disks.list",
    "compute.disks.setLabels",
    "compute.disks.use",
    "compute.firewalls.create",
    "compute.firewalls.delete",
    "compute.firewalls.get",
    "compute.firewalls.list",
    "compute.globalOperations.get",
    "compute.images.get",
    "compute.images.getFromFamily",
    "compute.images.list",
    "compute.images.useReadOnly",
    "compute.instances.addAccessConfig",
    "compute.instances.attachDisk",
    "compute.instances.create",
    "compute.instances.delete",
    "compute.instances.detachDisk",
    "compute.instances.get",
    "compute.instances.getSerialPortOutput",
    "compute.instances.list",
    "compute.instances.setDeletionProtection",
    "compute.instances.setLabels",
    "compute.instances.setMachineType",
    "compute.instances.setMetadata",
    "compute.instances.setServiceAccount",
    "compute.instances.setTags",
    "compute.instances.start",
    "compute.instances.stop",
    "compute.instances.updateDisplayDevice",
    "compute.machineTypes.get",
    "compute.networks.get",
    "compute.networks.list",
    "compute.networks.updatePolicy",
    "compute.projects.get",
    "compute.regionBackendServices.create",
    "compute.regionBackendServices.get",
    "compute.regionBackendServices.list",
    "compute.regions.get",
    "compute.regions.list",
    "compute.snapshots.create",
    "compute.snapshots.delete",
    "compute.snapshots.get",
    "compute.snapshots.list",
    "compute.snapshots.setLabels",
    "compute.subnetworks.get",
    "compute.subnetworks.list",
    "compute.subnetworks.use",
    "compute.subnetworks.useExternalIp",
    "compute.zoneOperations.get",
    "compute.zones.get",
    "compute.zones.list",
    "deploymentmanager.compositeTypes.get",
    "deploymentmanager.compositeTypes.list",
    "deploymentmanager.deployments.create",
    "deploymentmanager.deployments.delete",
    "deploymentmanager.deployments.get",
    "deploymentmanager.deployments.list",
    "deploymentmanager.manifests.get",
    "deploymentmanager.manifests.list",
    "deploymentmanager.operations.get",
    "deploymentmanager.operations.list",
    "deploymentmanager.resources.get",
    "deploymentmanager.resources.list",
    "deploymentmanager.typeProviders.get",
    "deploymentmanager.typeProviders.list",
    "deploymentmanager.types.get",
    "deploymentmanager.types.list",
    "iam.serviceAccounts.actAs",
    "iam.serviceAccounts.getIamPolicy",
    "iam.serviceAccounts.list",
    "logging.logEntries.list",
    "logging.privateLogEntries.list",
    "resourcemanager.projects.get",
    "storage.buckets.create",
    "storage.buckets.delete",
    "storage.buckets.get",
    "storage.buckets.list",
    "storage.buckets.update",
    "storage.objects.get",
    "storage.objects.list",
  ])
}

resource "google_project_iam_binding" "deploy" {
  role = google_project_iam_custom_role.deploy.id

  members = [
    "serviceAccount:${google_service_account.deploy.email}",
  ]
}

resource "google_service_account_key" "deploy" {
  service_account_id = google_service_account.deploy.name
}

resource "netapp-cloudmanager_connector_gcp" "this" {
  name                  = "netapp-test"
  zone                  = "us-east4-a"
  company               = "MyCompany"
  service_account_email = google_service_account.deploy.email
  service_account_key  = google_service_account_key.deploy.private_key
  account_id            = var.account
  associate_public_ip   = false
}
```