### PR TITLE
fix replication import

### DIFF
--- a/cloudmanager/resource_netapp_cloudmanager_snapmirror.go
+++ b/cloudmanager/resource_netapp_cloudmanager_snapmirror.go
@@ -1,6 +1,7 @@
 package cloudmanager
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -16,7 +17,7 @@ func resourceCVOSnapMirror() *schema.Resource {
 		Exists: resourceCVOSnapMirrorExists,
 		Update: resourceCVOSnapMirrorUpdate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceCVOSnapMirrorImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"source_working_environment_id": {
@@ -315,4 +316,87 @@ func resourceCVOSnapMirrorExists(d *schema.ResourceData, meta interface{}) (bool
 func resourceCVOSnapMirrorUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	return nil
+}
+
+func resourceCVOSnapMirrorImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	log.Printf("Importing SnapMirror with ID: %s", d.Id())
+
+	client := meta.(*Client)
+	importID := d.Id()
+
+	// Parse the import ID - expect format: client_id:destination_volume_name
+	parts := strings.Split(importID, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid import ID format. Expected: client_id:destination_volume_name, got: %s", importID)
+	}
+
+	clientID := parts[0]
+	destinationVolumeName := parts[1]
+
+	// Check deployment mode
+	isSaas, connectorIP, err := client.checkDeploymentMode(d, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check deployment mode during import: %v", err)
+	}
+
+	// Try to find the snapmirror relationship by destination volume name
+	relationship, err := client.findSnapMirrorByDestinationVolume(destinationVolumeName, clientID, isSaas, connectorIP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find snapmirror relationship during import: %v", err)
+	}
+
+	// Set the ID and populate the required fields
+	d.SetId(destinationVolumeName)
+	d.Set("client_id", clientID)
+	d.Set("source_working_environment_id", relationship.Source.WorkingEnvironmentID)
+	d.Set("destination_working_environment_id", relationship.Destination.WorkingEnvironmentID)
+	d.Set("source_volume_name", relationship.Source.VolumeName)
+	d.Set("destination_volume_name", relationship.Destination.VolumeName)
+	d.Set("source_svm_name", relationship.Source.SvmName)
+	d.Set("destination_svm_name", relationship.Destination.SvmName)
+	d.Set("policy", relationship.Policy)
+	d.Set("schedule", relationship.Schedule)
+	d.Set("max_transfer_rate", relationship.MaxTransferRate.Size)
+
+	// Set default values for fields that have them in the schema
+	d.Set("deployment_mode", "Standard")
+	d.Set("delete_destination_volume", false)
+
+	// Set optional fields if they exist, otherwise set appropriate defaults
+	if relationship.Destination.AggregateName != "" {
+		d.Set("destination_aggregate_name", relationship.Destination.AggregateName)
+	}
+	if relationship.Destination.ProviderVolumeType != "" {
+		d.Set("provider_volume_type", relationship.Destination.ProviderVolumeType)
+	}
+	if relationship.Destination.CapacityTier != "" && relationship.Destination.CapacityTier != "none" {
+		d.Set("capacity_tier", relationship.Destination.CapacityTier)
+	} else {
+		d.Set("capacity_tier", "none")
+	}
+
+	// Try to get additional volume information from the destination working environment
+	// This is needed because the status API doesn't include all volume details
+	if relationship.Destination.WorkingEnvironmentID != "" {
+		volumeRequest := volumeRequest{
+			WorkingEnvironmentID: relationship.Destination.WorkingEnvironmentID,
+			Name:                 relationship.Destination.VolumeName,
+		}
+
+		volumes, err := client.getVolume(volumeRequest, clientID, isSaas, connectorIP)
+		if err == nil && len(volumes) > 0 {
+			volume := volumes[0]
+			if volume.AggregateName != "" {
+				d.Set("destination_aggregate_name", volume.AggregateName)
+			}
+			if volume.ProviderVolumeType != "" {
+				d.Set("provider_volume_type", volume.ProviderVolumeType)
+			}
+			if volume.CapacityTier != "" {
+				d.Set("capacity_tier", volume.CapacityTier)
+			}
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
Problem: ImportStatePassthrough in the replication SnamMirror resource only populated the resource ID (destination_volume_name) but the Read function needed:

- source_working_environment_id
- destination_working_environment_id
- client_id
- Other fields for proper state management

We fixed it by:
- Created Custom Import Function
- Added API Methods for Import to query all relationships from /occm/api/replication/all-relationships and get detailed status for specific working environments
- Implemented Composite Import ID
``` bash
# Import format: client_id:destination_volume_name
terragrunt import 'resource_name' client_id:destination_volume_name
```
- Fixed API Response Structure Issues: API returned {"size": 100000, "unit": "KB"} but code expected simple integer.
- Complete Field Population During Import